### PR TITLE
Use better methods for generating entropy

### DIFF
--- a/jsbn/rng.js
+++ b/jsbn/rng.js
@@ -10,7 +10,8 @@ if(rng_pool == null) {
   var t;
   if(window.crypto && window.crypto.getRandomValues) {
     // Extract entropy (2048 bits) from RNG if available
-    var z = window.crypto.getRandomValues(new Uint32Array(256));
+    var z = new Uint32Array(256);
+    window.crypto.getRandomValues(z);
     for (t = 0; t < z.length; ++t)
       rng_pool[rng_pptr++] = z[t] & 255;
   } 


### PR DESCRIPTION
The jsbn libraries are a bit old, last modified in 2009 to be exact.  Crypto in the browser has come a long way since then, and I generally feel that the way it generates entropy could be greatly improved.

Using time to generate random values is well, not random.  Math.random() is not as good as using crypto.getRandomValues, and while the RNG included in jsbn does attempt to use crypto.random, that API seems to be very old and not supported on modern browsers.

Up to you if you would like to accept this, as you state that the jsbn files have been copied over exactly.  Not sure what your stance is on modifying them.  This pull request does a few things:
- Prefers crypto.getRandomValues
- Falls back to collecting entropy via mouse movement.
- When the PRNG (Arcfour) is initiated, if there is not enough entropy from getRandomValues or mouse movement, it falls back to Math.random.

I am currently using these changes in a live system (http://www.cyanogenmod.org/blog/cyanogenmod-account) that has a lot of "tinfoil hat" users, and would love to see them upstream :)
