### PR TITLE
Specified the main file in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jsencrypt",
   "version": "2.1.0",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
+  "main": "bin/jsencrypt.js",
   "author": {
     "name": "Travis Tidwell",
     "email": "travist349@gmail.com",


### PR DESCRIPTION
This change lets webpack users import JSEncrypt using

``` js
import JSEncrypt from 'jsencrypt';
```

Instead of

``` js
import JSEncrypt from 'jsencrypt/bin/jsencrypt';
```

Please tag a new fix release including this change!