### PR TITLE
Bower name fix

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
-  "name": "travist/jsencrypt",
+  "name": "jsencrypt",
   "version": "2.1.0",
   "main": "bin/jsencrypt.min.js",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",


### PR DESCRIPTION
I was experiencing errors when trying to install using bower. This is most likely caused by the / in the bower.json name: https://github.com/bower/spec/blob/master/json.md#name