### PR TITLE
Protect against permission denied error when accessing mouse coordinates

### DIFF
--- a/lib/jsbn/rng.js
+++ b/lib/jsbn/rng.js
@@ -27,9 +27,13 @@ if(rng_pool == null) {
         window.detachEvent("onmousemove", onMouseMoveListener);
       return;
     }
-    this.count += 1;
-    var mouseCoordinates = ev.x + ev.y;
-    rng_pool[rng_pptr++] = mouseCoordinates & 255;
+    try {
+      var mouseCoordinates = ev.x + ev.y;
+      rng_pool[rng_pptr++] = mouseCoordinates & 255;
+      this.count += 1;
+    } catch (e) {
+      // Sometimes Firefox will deny permission to access event properties for some reason. Ignore.
+    }
   };
   if (window.addEventListener)
     window.addEventListener("mousemove", onMouseMoveListener, false);


### PR DESCRIPTION
For some reason, Firefox will sometimes throw a permission denied exception when trying to access `ev.x` and `ev.y` when gathering entropy from mouse movements.  I haven't been able to reproduce this myself but it happened to 10+ users on reviewable.io, so it's not that rare a problem.  I don't know if the error is transient or permanent -- if it's transient, later mouse move events will fill up the entropy pool, and if it's permanent it should fall back on `Math.random()` as usual.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/travist/jsencrypt/67)
<!-- Reviewable:end -->
