### PR TITLE
Point bower.json main to bin/jsencrypt.js.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "jsencrypt",
   "version": "2.1.0",
-  "main": "bin/jsencrypt.min.js",
+  "main": "bin/jsencrypt.js",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
   "license": "MIT",
   "ignore": [],


### PR DESCRIPTION
Bower's main is not supposed to point to minified files, and bin/jsencrypt.min.js is not checked in anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/travist/jsencrypt/68)
<!-- Reviewable:end -->
