### PR TITLE
Added npm ignore and prepublish task

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,14 @@
+_includes
+_layouts
+demo
+lib
+src
+test
+_config.build.yml
+_config.yml
+.gitignore
+bower.json
+example.html
+gulpfile.js
+index.html
+jquery.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "2.3.0",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
   "main": "bin/jsencrypt.js",
+  "scripts": {
+    "prepublish": "node_modules/gulp/bin/gulp.js"
+  },
   "contributors": [
     {
       "name": "Travis Tidwell",
@@ -12,6 +15,10 @@
     {
       "name": "Antonio",
       "url": "https://github.com/zoloft"
+    },
+    {
+      "name": "Julio",
+      "url": "https://github.com/jmgaya"
     }
   ],
   "homepage": "http://www.travistidwell.com/jsencrypt",


### PR DESCRIPTION
I've just fixed how you expose JSEncrypt as a **NPM module.** When installing, you're getting lot of don't needed stuff, so I've added a .npmignore and a "prepublish" task for generating what you're exposing in the package.json as **main**.