### PR TITLE
Fix tests setup

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -2,12 +2,14 @@
 title: Testing JSEncrypt
 layout: default
 ---
-<link href="test/mocha.css" rel="stylesheet" type="text/css">
+<link href="mocha.css" rel="stylesheet" type="text/css">
 <div id="mocha"></div>
-<script type="text/javascript" src="test/expect.js"></script>
-<script type="text/javascript" src="test/mocha.js"></script>
+<script type="text/javascript" src="expect.js"></script>
+<script type="text/javascript" src="mocha.js"></script>
 <script>mocha.setup('bdd')</script>
-<script type="text/javascript" src="test/test.rsa.js"></script>
+<script type="text/javascript" src="../jquery.js"></script>
+<script type="text/javascript" src="../bin/jsencrypt.js"></script>
+<script type="text/javascript" src="test.rsa.js"></script>
 <script>
   mocha.checkLeaks();
   mocha.globals(['jQuery']);


### PR DESCRIPTION
Currently, `tests/index.html` does not work due to a few errors. This change fixes those errors to allow the test suite to run correctly in the browser.

Results from hitting `tests/index.html` with this change:

<img width="605" alt="screen shot 2016-08-08 at 6 06 37 pm" src="https://cloud.githubusercontent.com/assets/18747026/17498074/12207494-5d93-11e6-813f-2ba86a3c0398.png">
