### PR TITLE
Include license (MIT) in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "jsencrypt",
   "version": "2.3.1",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
+  "license": "MIT",
   "main": "bin/jsencrypt.js",
   "scripts": {
     "prepublish": "node_modules/gulp/bin/gulp.js"


### PR DESCRIPTION
The license is included in bower.json and LICENSE.txt specifies it to be as MIT so it'd be a nice addition to have it in package.json as well. 

😄 