### PR TITLE
Fix: error handling when navigator object is not defined

### DIFF
--- a/bin/jsencrypt.js
+++ b/bin/jsencrypt.js
@@ -2621,11 +2621,12 @@ function am3(i, x, w, j, c, n) {
     }
     return c;
 }
-if (j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
+var inBrowser = typeof navigator !== "undefined";
+if (inBrowser && j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
     BigInteger.prototype.am = am2;
     dbits = 30;
 }
-else if (j_lm && (navigator.appName != "Netscape")) {
+else if (inBrowser && j_lm && (navigator.appName != "Netscape")) {
     BigInteger.prototype.am = am1;
     dbits = 26;
 }

--- a/lib/jsbn/jsbn.ts
+++ b/lib/jsbn/jsbn.ts
@@ -1849,10 +1849,11 @@ function am3(i:number, x:number, w:BigInteger, j:number, c:number, n:number) {
     return c;
 }
 
-if (j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
+const inBrowser = typeof navigator !== "undefined";
+if (inBrowser && j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
     BigInteger.prototype.am = am2;
     dbits = 30;
-} else if (j_lm && (navigator.appName != "Netscape")) {
+} else if (inBrowser && j_lm && (navigator.appName != "Netscape")) {
     BigInteger.prototype.am = am1;
     dbits = 26;
 } else { // Mozilla/Netscape seems to prefer am3


### PR DESCRIPTION
This commit prevents the script break in runtime by handling navigator object when object is not defined

### Error ocurring

```
if(j_lm && (navigator.appName == "Microsoft Internet Explorer")) {
            ^ 

ReferenceError: navigator is not defined
```
### Soluction

Added a variable to check it.
`
var inBrowser = typeof navigator !== "undefined";
`

