### PR TITLE
Support for ESM, CommonJS, and Typescript

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "jsencrypt",
   "version": "3.1.0",
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
-  "main": "lib/index.js",
+  "main": "bin/jsencrypt.js",
+  "module": "lib/index.js",
+  "types": "lib/index.d.ts",
   "dependencies": {},
   "devDependencies": {
     "typescript": "^4.2.3",


### PR DESCRIPTION
Currently this module has the ESM package under the main key in package.json, this will only work if ESM is enabled in your environment. Instead what is recommended is to point "main" to your CommonJS package and to use the "module" key for the ESM package.

In addition to support TypeScript for both ESM and CommonJS I have specified the "types" key.

References:
 - https://nodejs.org/api/packages.html#packages_dual_commonjs_es_module_packages
 - https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html

Resolves:
#211, #199 
