### PR TITLE
Fix add default args for JSEncrypt constructor

### DIFF
--- a/src/JSEncrypt.ts
+++ b/src/JSEncrypt.ts
@@ -18,7 +18,7 @@ export interface IJSEncryptOptions {
  * @constructor
  */
 export class JSEncrypt {
-    constructor(options:IJSEncryptOptions) {
+    constructor(options:IJSEncryptOptions = {}) {
         options = options || {};
         this.default_key_size = options.default_key_size ? parseInt(options.default_key_size, 10) : 1024;
         this.default_public_exponent = options.default_public_exponent || "010001"; // 65537 default openssl public exponent for rsa key type
@@ -203,4 +203,3 @@ export class JSEncrypt {
         return this.getKey().getPublicBaseKeyB64();
     }
 }
-


### PR DESCRIPTION
```
new JSEncrypt() // Expected 1 arguments, but got 0.ts(2554)
                // JSEncrypt.ts(21, 17): An argument for 'options' was not provided.
```

`new JSEncrypt()` will report an error when I write in TypeScript. But in README's usage demo, it is just called `new JSEncrypt()` in JavaScript code. I think options should add a default arg so that TypeScript and JavaScript developer has same behaviour.