### PR TITLE
Use IE11's secure RNG if possible

### DIFF
--- a/lib/lib/jsbn/rng.js
+++ b/lib/lib/jsbn/rng.js
@@ -8,10 +8,11 @@ if (rng_pool == null) {
     rng_pool = [];
     rng_pptr = 0;
     var t = void 0;
-    if (window.crypto && window.crypto.getRandomValues) {
+    var crypto = window.crypto || window.msCrypto
+    if (crypto && crypto.getRandomValues) {
         // Extract entropy (2048 bits) from RNG if available
         var z = new Uint32Array(256);
-        window.crypto.getRandomValues(z);
+        crypto.getRandomValues(z);
         for (t = 0; t < z.length; ++t) {
             rng_pool[rng_pptr++] = z[t] & 255;
         }

--- a/lib/lib/jsbn/rng.js
+++ b/lib/lib/jsbn/rng.js
@@ -8,7 +8,7 @@ if (rng_pool == null) {
     rng_pool = [];
     rng_pptr = 0;
     var t = void 0;
-    var crypto = window.crypto || window.msCrypto
+    var crypto = window.crypto || window.msCrypto;
     if (crypto && crypto.getRandomValues) {
         // Extract entropy (2048 bits) from RNG if available
         var z = new Uint32Array(256);


### PR DESCRIPTION
Modifies rng.js to use IE11's secure RNG if possible, which is located under `window.msCrypto`.