### PR TITLE
Specify file to be imported for react-native

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A Javascript library to perform OpenSSL RSA Encryption, Decryption, and Key Generation.",
   "main": "bin/jsencrypt.js",
   "module": "lib/index.js",
+  "browser": "lib/index.js",
   "types": "lib/index.d.ts",
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
In the current setup metro bundler tires to import and parse `bin/jsencrypt.js` and it results in the following errors:

```
Error: ENOENT: no such file or directory, open '/Users/<path to the project>/packages/app/webpack:/JSEncrypt/lib/index.js?'
    at Object.openSync (node:fs:599:3)
    at Object.readFileSync (node:fs:467:35)
    at getCodeFrame (/Users/<path to the project>/node_modules/metro/src/Server.js:949:18)
    at Server._symbolicate (/Users/<path to the project>/node_modules/metro/src/Server.js:1022:22)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Server._processRequest (/Users/<path to the project>/node_modules/metro/src/Server.js:429:7) {
  errno: -2,
  syscall: 'open',
  code: 'ENOENT',
  path: '/Users/<path to the project>/packages/app/webpack:/JSEncrypt/lib/index.js?'
}
 ERROR  ReferenceError: Property '__webpack_require__' doesn't exist, js engine: hermes
 WARN  Module OverrideColorScheme requires main queue setup since it overrides `init` but doesn't implement `requiresMainQueueSetup`. In a future release React Native will default to initializing all native modules on a background thread unless explicitly opted-out of.
 ERROR  Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication). A frequent cause of the error is that the application entry file path is incorrect.
      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native., js engine: hermes
 ERROR  Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication). A frequent cause of the error is that the application entry file path is incorrect.
      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native., js engine: hermes
 ERROR  Invariant Violation: Module AppRegistry is not a registered callable module (calling unmountApplicationComponentAtRootTag). A frequent cause of the error is that the application entry file path is incorrect.
      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native., js engine: hermes
 ERROR  Invariant Violation: Module AppRegistry is not a registered callable module (calling runApplication). A frequent cause of the error is that the application entry file path is incorrect.
      This can also happen when the JS bundle is corrupt or there is an early initialization error when loading React Native., js engine: hermes
```


Metro bundler does not respect field "module" and it tries to resolve either "browser" or "react-native" before that.

Fixes https://github.com/travist/jsencrypt/issues/261