### PR TITLE
fix: Use globalThis instead of window, to solve the problem that wind…

### DIFF
--- a/src/lib/jsbn/rng.ts
+++ b/src/lib/jsbn/rng.ts
@@ -10,10 +10,10 @@ if (rng_pool == null) {
   rng_pool = [];
   rng_pptr = 0;
   let t;
-  if (typeof window !== 'undefined' && window.crypto && window.crypto.getRandomValues) {
+  if (typeof globalThis !== 'undefined' && globalThis.crypto && globalThis.crypto.getRandomValues) {
     // Extract entropy (2048 bits) from RNG if available
     const z = new Uint32Array(256);
-    window.crypto.getRandomValues(z);
+    globalThis.crypto.getRandomValues(z);
     for (t = 0; t < z.length; ++t) {
         rng_pool[rng_pptr++] = z[t] & 255;
     }
@@ -25,10 +25,10 @@ if (rng_pool == null) {
   const onMouseMoveListener = function (ev:Event & {x:number; y:number; }) {
     count = count || 0;
     if (count >= 256 || rng_pptr >= rng_psize) {
-      if (window.removeEventListener) {
-          window.removeEventListener("mousemove", onMouseMoveListener, false);
-      } else if ((window as any).detachEvent) {
-          (window as any).detachEvent("onmousemove", onMouseMoveListener);
+      if (globalThis.removeEventListener) {
+          globalThis.removeEventListener("mousemove", onMouseMoveListener, false);
+      } else if ((globalThis as any).detachEvent) {
+          (globalThis as any).detachEvent("onmousemove", onMouseMoveListener);
       }
       return;
     }
@@ -40,11 +40,11 @@ if (rng_pool == null) {
       // Sometimes Firefox will deny permission to access event properties for some reason. Ignore.
     }
   };
-  if (typeof window !== 'undefined') {
-    if (window.addEventListener) {
-        window.addEventListener("mousemove", onMouseMoveListener, false);
-    } else if ((window as any).attachEvent) {
-        (window as any).attachEvent("onmousemove", onMouseMoveListener);
+  if (typeof globalThis !== 'undefined') {
+    if (globalThis.addEventListener) {
+        globalThis.addEventListener("mousemove", onMouseMoveListener, false);
+    } else if ((globalThis as any).attachEvent) {
+        (globalThis as any).attachEvent("onmousemove", onMouseMoveListener);
     }
   }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -11,7 +11,7 @@ export default {
         library: "JSEncrypt",
         libraryTarget: "umd",
         libraryExport: "default",
-        globalObject: "window",
+        globalObject: "globalThis",
         path: path.resolve(__dirname, "bin"),
         filename: "jsencrypt.js",
     },

--- a/webpack.test.js
+++ b/webpack.test.js
@@ -11,7 +11,7 @@ export default {
         library: "JSEncrypt",
         libraryTarget: "umd",
         libraryExport: "default",
-        globalObject: "window",
+        globalObject: "globalThis",
         path: path.resolve(__dirname, "test"),
         filename: "test.rsa.bundle.js",
     },


### PR DESCRIPTION
When I encountered this error in my Node.js code:

**})(window, () => {
   ^
ReferenceError: window is not defined
    at Object.<anonymous> (E:\company\secret-test\node_modules\jsencrypt\bin\jsencrypt.js:**

You know, globalThis provides a standardized way to access the global ‘this’ object in different environments. Unlike properties like ‘window’ or ‘self,’ it ensures that it works consistently in various environments, whether there is a window or not。

After replacing the window object, I was able to resolve this error






